### PR TITLE
Also add tags as children to groups.

### DIFF
--- a/inventory.py
+++ b/inventory.py
@@ -163,9 +163,19 @@ class Groups:
                     path.pop()
                 hst = Host(h, path)
                 fullpath = "-".join(path)
-                if not 'hosts' in _data[fullpath]:
-                    _data[fullpath]['hosts'] = []
-                _data[fullpath]['hosts'].append(hst.name)
+                for t in hst.tags:
+                    tagfullpath = "{}-{}".format(fullpath,t)
+
+                    if not tagfullpath in _data:
+                        _data[tagfullpath] = {}
+                    if not 'hosts' in _data[tagfullpath]:
+                        _data[tagfullpath]['hosts'] = []
+
+                    _data[tagfullpath]['hosts'].append(hst.name)
+
+                    if not 'children' in _data[fullpath]:
+                        _data[fullpath]['children'] = []
+                    _data[fullpath]['children'].append(tagfullpath)
 
 class TagVars:
     def __init__(self, tag, val):

--- a/tests/test-groups/inventory_tests.py
+++ b/tests/test-groups/inventory_tests.py
@@ -44,7 +44,16 @@ class AnsibleInventoryTests(unittest.TestCase):
         yml = self.yml_inv.get_variables("myhost1.example.com")
         result = {
             'inventory_hostname': u'myhost1.example.com',
-            'group_names': [u'com', u'example', u'myhost', u'root', u'root-docker'],
+            'group_names': [
+                u'com',
+                u'example',
+                u'myhost',
+                u'root',
+                u'root-docker',
+                u'root-docker-com',
+                u'root-docker-example',
+                u'root-docker-myhost'
+                ],
             'inventory_hostname_short': u'myhost1'
             }
         self.assertDictEqual(yml, result, msg="\nGot:    {}\nExpect: {}".format(yml, result))
@@ -53,7 +62,17 @@ class AnsibleInventoryTests(unittest.TestCase):
         yml = self.yml_inv.get_variables("myhost2.example.com")
         result = {
             'inventory_hostname': u'myhost2.example.com',
-            'group_names': [u'com', u'example', u'myhost', u'root', u'root-docker', u'root-docker-site_a'],
+            'group_names': [
+                u'com',
+                u'example',
+                u'myhost',
+                u'root',
+                u'root-docker',
+                u'root-docker-site_a',
+                u'root-docker-site_a-com',
+                u'root-docker-site_a-example',
+                u'root-docker-site_a-myhost'
+                ],
             'inventory_hostname_short': u'myhost2'
             }
         self.assertDictEqual(yml, result, msg="\nGot:    {}\nExpect: {}".format(yml, result))
@@ -62,7 +81,18 @@ class AnsibleInventoryTests(unittest.TestCase):
         yml = self.yml_inv.get_variables("myhost3.example.com")
         result = {
             'inventory_hostname': u'myhost3.example.com',
-            'group_names': [u'com', u'example', u'myhost', u'root', u'root-docker', u'root-docker-site_b', u'root-docker-site_b-my_foo_group'],
+            'group_names': [
+                u'com',
+                u'example',
+                u'myhost',
+                u'root',
+                u'root-docker',
+                u'root-docker-site_b',
+                u'root-docker-site_b-my_foo_group',
+                u'root-docker-site_b-my_foo_group-com',
+                u'root-docker-site_b-my_foo_group-example',
+                u'root-docker-site_b-my_foo_group-myhost'
+                ],
             'inventory_hostname_short': u'myhost3'
             }
         self.assertDictEqual(yml, result, msg="\nGot:    {}\nExpect: {}".format(yml, result))

--- a/tests/test-hosts/inventory_tests.py
+++ b/tests/test-hosts/inventory_tests.py
@@ -44,7 +44,16 @@ class AnsibleInventoryTests(unittest.TestCase):
         yml = self.yml_inv.get_variables("myhost1.example.com")
         result = {
             'inventory_hostname': u'myhost1.example.com',
-            'group_names': [u'com', u'example', u'myhost', u'root', u'root-docker'],
+            'group_names': [
+                u'com',
+                u'example',
+                u'myhost',
+                u'root',
+                u'root-docker',
+                u'root-docker-com',
+                u'root-docker-example',
+                u'root-docker-myhost'
+                ],
             'inventory_hostname_short': u'myhost1'
             }
         self.assertDictEqual(yml, result, msg="\nGot:    {}\nExpect: {}".format(yml, result))

--- a/tests/test-matcher/inventory_tests.py
+++ b/tests/test-matcher/inventory_tests.py
@@ -46,6 +46,13 @@ class AnsibleInventoryTests(unittest.TestCase):
             u'com',
             u'example',
             u'root',
+            u'root-com',
+            u'root-example',
+            u'root-site', # from matcher group
+            u'root-sto',
+            u'root-stowww',
+            u'root-test', # from matcher group
+            u'root-www',
             u'site',
             u'sto',
             u'stowww',
@@ -62,6 +69,12 @@ class AnsibleInventoryTests(unittest.TestCase):
             u'lon',
             u'lonwww',
             u'root',
+            u'root-com',
+            u'root-example',
+            u'root-lon',
+            u'root-lonwww',
+            u'root-site', # from matcher groups
+            u'root-www',
             u'site',
             u'www'
         ]
@@ -75,7 +88,12 @@ class AnsibleInventoryTests(unittest.TestCase):
             u'example',
             u'lon',
             u'londb',
-            u'root'
+            u'root',
+            u'root-com',
+            u'root-db',
+            u'root-example',
+            u'root-lon',
+            u'root-londb'
         ]
         self.assertListEqual(yml['group_names'], result, msg="\nGot:    {}\nExpect: {}".format(yml['group_names'], result))
 

--- a/tests/test-name-root/inventory_tests.py
+++ b/tests/test-name-root/inventory_tests.py
@@ -44,7 +44,16 @@ class AnsibleInventoryTests(unittest.TestCase):
         yml = self.yml_inv.get_variables("myhost1.example.com")
         result = {
             'inventory_hostname': u'myhost1.example.com',
-            'group_names': [u'com', u'example', u'foo', u'foo-docker', u'myhost'],
+            'group_names': [
+                u'com',
+                u'example',
+                u'foo',
+                u'foo-docker',
+                u'foo-docker-com',
+                u'foo-docker-example',
+                u'foo-docker-myhost',
+                u'myhost'
+                ],
             'inventory_hostname_short': u'myhost1'
             }
         self.assertDictEqual(yml, result, msg="\nGot:    {}\nExpect: {}".format(yml, result))

--- a/tests/test-plain/inventory_tests.py
+++ b/tests/test-plain/inventory_tests.py
@@ -44,7 +44,16 @@ class AnsibleInventoryTests(unittest.TestCase):
         yml = self.yml_inv.get_variables("myhost1.example.com")
         result = {
             'inventory_hostname': u'myhost1.example.com',
-            'group_names': [u'com', u'example', u'myhost', u'root', u'root-docker'],
+            'group_names': [
+                u'com',
+                u'example',
+                u'myhost',
+                u'root',
+                u'root-docker',
+                u'root-docker-com',
+                u'root-docker-example',
+                u'root-docker-myhost'
+                ],
             'inventory_hostname_short': u'myhost1'
             }
         self.assertDictEqual(yml, result, msg="\nGot:    {}\nExpect: {}".format(yml, result))

--- a/tests/test-tags/inventory_tests.py
+++ b/tests/test-tags/inventory_tests.py
@@ -45,7 +45,16 @@ class AnsibleInventoryTests(unittest.TestCase):
         result = {
             'inventory_hostname': u'myhost2.example.com',
             'group_names': [
-                u'com', u'example', u'myhost', u'mytag', u'root', u'root-docker'
+                u'com',
+                u'example',
+                u'myhost',
+                u'mytag',
+                u'root',
+                u'root-docker',
+                u'root-docker-com',
+                u'root-docker-example',
+                u'root-docker-myhost',
+                u'root-docker-mytag'
                 ],
             'inventory_hostname_short': u'myhost2'
             }
@@ -55,7 +64,16 @@ class AnsibleInventoryTests(unittest.TestCase):
         yml = self.yml_inv.get_variables("myhost1.example.com")
         result = {
             'inventory_hostname': u'myhost1.example.com',
-            'group_names': [u'com', u'example', u'myhost', u'root', u'root-docker'],
+            'group_names': [
+                u'com',
+                u'example',
+                u'myhost',
+                u'root',
+                u'root-docker',
+                u'root-docker-com',
+                u'root-docker-example',
+                u'root-docker-myhost'
+                ],
             'inventory_hostname_short': u'myhost1'
             }
         self.assertDictEqual(yml, result, msg="\nGot:    {}\nExpect: {}".format(yml, result))


### PR DESCRIPTION
Consider this yaml:

``` yaml
root:
  - lon-myhost01
```

We usually created this structure from this:

```
root   -> lon-myhost01
lon    -> lon-myhost01
myhost -> lon-myhost01
```

This PR _also_ adds the tag groups as children, like this:

```
root        -> children: root-lon, root-myhost
root-lon    -> lon-myhost01
root-myhost -> lon-myhost01
lon         -> lon-myhost01
myhost      -> lon-myhost01
```

So you can use group_vars and access group lists from templates easier.
