### PR TITLE
Use yaml.full_load since yaml.load is not safe.

### DIFF
--- a/dockerfiles/local-test-base
+++ b/dockerfiles/local-test-base
@@ -5,7 +5,9 @@ RUN apt-get -y update \
     && apt-get -y install \
         python-pip \
         python-dev \
-    && apt-get -y clean
+    && apt-get -y clean \
+    && pip install --upgrade pip \
+    && pip install pyyaml==5.1
 
 RUN adduser \
     --home /tmp \

--- a/inventory.py
+++ b/inventory.py
@@ -53,7 +53,7 @@ def print_json(data):
 # Load the YAML file
 def load_file(file_name):
     with open(file_name, 'r') as fh:
-        return yaml.load(fh)
+        return yaml.full_load(fh)
 
 def get_yaml(file_name):
     script_path = os.path.dirname(os.path.realpath(__file__))

--- a/tests/test-group-vars/inventory_tests.py
+++ b/tests/test-group-vars/inventory_tests.py
@@ -34,32 +34,30 @@ import unittest
 import operator
 
 from ansible import errors
-from ansible.inventory import Inventory
+from ansible.inventory.manager import InventoryManager
 from ansible.parsing.dataloader import DataLoader
-from ansible.vars import VariableManager
+from ansible.vars.manager import VariableManager
 
 class AnsibleInventoryTests(unittest.TestCase):
-    var_manager = VariableManager()
     dataloader = DataLoader()
-    yml_inv = Inventory(
-        host_list="{}/inv.sh".format(os.path.dirname(__file__)),
-        loader=dataloader,
-        variable_manager=var_manager
-    )
+    yml_inv = InventoryManager(
+        sources="{}/inv.sh".format(os.path.dirname(__file__)),
+        loader=dataloader)
+    var_manager = VariableManager(loader=dataloader, inventory=yml_inv)
 
     def test_check_group_var(self):
         host = self.yml_inv.list_hosts("myhost1.example.com")[0]
-        yml = self.var_manager.get_vars(self.dataloader, host=host)
+        yml = self.var_manager.get_vars(host=host)
         self.assertEqual(yml['version'], 1.6, msg="Failed to get group variable")
 
     def test_that_host_vars_supersedes_group_vars(self):
         host = self.yml_inv.list_hosts("myhost2.example.com")[0]
-        yml = self.var_manager.get_vars(self.dataloader, host=host)
+        yml = self.var_manager.get_vars(host=host)
         self.assertEqual(yml['version'], 2.0, msg="Failed to get group variable")
 
     def test_that_we_can_set_vars_to_root(self):
         host = self.yml_inv.list_hosts("myhost3.example.com")[0]
-        yml = self.var_manager.get_vars(self.dataloader, host=host)
+        yml = self.var_manager.get_vars(host=host)
         self.assertEqual(yml['version'], 1.0, msg="Failed to get group variable")
 
 if __name__ == '__main__':

--- a/tests/test-groups/inventory_tests.py
+++ b/tests/test-groups/inventory_tests.py
@@ -34,21 +34,22 @@ import unittest
 import operator
 
 from ansible import errors
-from ansible.inventory import Inventory
+from ansible.inventory.manager import InventoryManager
 from ansible.parsing.dataloader import DataLoader
-from ansible.vars import VariableManager
+from ansible.vars.manager import VariableManager
 
 class AnsibleInventoryTests(unittest.TestCase):
-    var_manager = VariableManager()
     dataloader = DataLoader()
-    yml_inv = Inventory(
-        host_list="{}/inv.sh".format(os.path.dirname(__file__)),
-        loader=dataloader,
-        variable_manager=var_manager
+    yml_inv = InventoryManager(
+        sources="{}/inv.sh".format(os.path.dirname(__file__)),
+        loader=dataloader
     )
+    var_manager = VariableManager(loader=dataloader, inventory=yml_inv)
 
     def test_check_group_vars_host1(self):
-        yml = self.yml_inv.get_vars("myhost1.example.com")
+        yml = self.yml_inv.get_host("myhost1.example.com").get_vars()
+        yml.pop('inventory_file',None)
+        yml.pop('inventory_dir',None)
         result = {
             'inventory_hostname': u'myhost1.example.com',
             'group_names': [
@@ -66,7 +67,9 @@ class AnsibleInventoryTests(unittest.TestCase):
         self.assertDictEqual(yml, result, msg="\nGot:    {}\nExpect: {}".format(yml, result))
 
     def test_check_group_vars_host2(self):
-        yml = self.yml_inv.get_vars("myhost2.example.com")
+        yml = self.yml_inv.get_host("myhost2.example.com").get_vars()
+        yml.pop('inventory_file',None)
+        yml.pop('inventory_dir',None)
         result = {
             'inventory_hostname': u'myhost2.example.com',
             'group_names': [
@@ -85,7 +88,9 @@ class AnsibleInventoryTests(unittest.TestCase):
         self.assertDictEqual(yml, result, msg="\nGot:    {}\nExpect: {}".format(yml, result))
 
     def test_check_group_vars_host3(self):
-        yml = self.yml_inv.get_vars("myhost3.example.com")
+        yml = self.yml_inv.get_host("myhost3.example.com").get_vars()
+        yml.pop('inventory_file',None)
+        yml.pop('inventory_dir',None)
         result = {
             'inventory_hostname': u'myhost3.example.com',
             'group_names': [
@@ -105,8 +110,8 @@ class AnsibleInventoryTests(unittest.TestCase):
         self.assertDictEqual(yml, result, msg="\nGot:    {}\nExpect: {}".format(yml, result))
 
     def test_list_hosts(self):
-        yml = sorted(self.yml_inv.list_hosts())
-        yml = list(map((lambda x : repr(x).decode('utf-8')), yml))
+        yml = self.yml_inv.list_hosts()
+        yml = sorted(list(map((lambda x : repr(x).decode('utf-8')), yml)))
 
         result = [u'myhost1.example.com', u'myhost2.example.com', u'myhost3.example.com']
         self.assertListEqual(yml, result, msg="\nGot:    {}\nExpect: {}".format(yml, result))

--- a/tests/test-hosts/inventory_tests.py
+++ b/tests/test-hosts/inventory_tests.py
@@ -34,23 +34,24 @@ import unittest
 import operator
 
 from ansible import errors
-from ansible.inventory import Inventory
+from ansible.inventory.manager import InventoryManager
 from ansible.parsing.dataloader import DataLoader
-from ansible.vars import VariableManager
+from ansible.vars.manager import VariableManager
 
 from pprint import pprint
 
 class AnsibleInventoryTests(unittest.TestCase):
     var_manager = VariableManager()
     dataloader = DataLoader()
-    yml_inv = Inventory(
-        host_list="{}/inv.sh".format(os.path.dirname(__file__)),
-        loader=dataloader,
-        variable_manager=var_manager
+    yml_inv = InventoryManager(
+        sources="{}/inv.sh".format(os.path.dirname(__file__)),
+        loader=dataloader
     )
 
     def test_check_host_vars_and_groups(self):
-        yml = self.yml_inv.get_vars("myhost1.example.com")
+        yml = self.yml_inv.get_host("myhost1.example.com").get_vars()
+        yml.pop('inventory_file',None)
+        yml.pop('inventory_dir',None)
         result = {
             'inventory_hostname': u'myhost1.example.com',
             'group_names': [
@@ -68,8 +69,8 @@ class AnsibleInventoryTests(unittest.TestCase):
         self.assertDictEqual(yml, result, msg="\nGot:    {}\nExpect: {}".format(yml, result))
 
     def test_list_hosts(self):
-        yml = sorted(self.yml_inv.list_hosts())
-        yml = list(map((lambda x : repr(x).decode('utf-8')), yml))
+        yml = self.yml_inv.list_hosts()
+        yml = sorted(list(map((lambda x : repr(x).decode('utf-8')), yml)))
 
         result = [u'myhost1.example.com', u'myhost2.example.com']
         self.assertListEqual(yml, result, msg="\nGot:    {}\nExpect: {}".format(yml, result))

--- a/tests/test-include/inventory_tests.py
+++ b/tests/test-include/inventory_tests.py
@@ -34,31 +34,30 @@ import unittest
 import operator
 
 from ansible import errors
-from ansible.inventory import Inventory
+from ansible.inventory.manager import InventoryManager
 from ansible.parsing.dataloader import DataLoader
-from ansible.vars import VariableManager
+from ansible.vars.manager import VariableManager
 
 class AnsibleInventoryTests(unittest.TestCase):
-    var_manager = VariableManager()
     dataloader = DataLoader()
-    yml_inv = Inventory(
-        host_list="{}/inv.sh".format(os.path.dirname(__file__)),
-        loader=dataloader,
-        variable_manager=var_manager
+    yml_inv = InventoryManager(
+        sources="{}/inv.sh".format(os.path.dirname(__file__)),
+        loader=dataloader
     )
+    var_manager = VariableManager(loader=dataloader, inventory=yml_inv)
 
     def test_check_include_order(self):
         host = self.yml_inv.list_hosts("myhost1.example.com")[0]
-        yml = self.var_manager.get_vars(self.dataloader, host=host)
+        yml = self.var_manager.get_vars(host=host)
         self.assertEqual(yml['dvar'], 1, msg="Error, dvar include wasn't a DFS")
 
     def test_check_include_twice(self):
         host = self.yml_inv.list_hosts("www1.example.com")[0]
-        yml = self.var_manager.get_vars(self.dataloader, host=host)
+        yml = self.var_manager.get_vars(host=host)
         self.assertEqual(yml['myvar1'], 3, msg="Error, failed to include twice!")
 
         host = self.yml_inv.list_hosts("www2.example.com")[0]
-        yml = self.var_manager.get_vars(self.dataloader, host=host)
+        yml = self.var_manager.get_vars(host=host)
         self.assertEqual(yml['myvar1'], 3, msg="Error, failed to include twice!")
 
 if __name__ == '__main__':

--- a/tests/test-matcher/inventory_tests.py
+++ b/tests/test-matcher/inventory_tests.py
@@ -34,21 +34,20 @@ import unittest
 import operator
 
 from ansible import errors
-from ansible.inventory import Inventory
+from ansible.inventory.manager import InventoryManager
 from ansible.parsing.dataloader import DataLoader
-from ansible.vars import VariableManager
+from ansible.vars.manager import VariableManager
 
 class AnsibleInventoryTests(unittest.TestCase):
-    var_manager = VariableManager()
     dataloader = DataLoader()
-    yml_inv = Inventory(
-        host_list="{}/inv.sh".format(os.path.dirname(__file__)),
-        loader=dataloader,
-        variable_manager=var_manager
+    yml_inv = InventoryManager(
+        sources="{}/inv.sh".format(os.path.dirname(__file__)),
+        loader=dataloader
     )
+    var_manager = VariableManager(loader=dataloader, inventory=yml_inv)
 
     def test_check_matcher_capture_on_stowww1(self):
-        yml = self.yml_inv.get_vars("stowww1.example.com")
+        yml = self.yml_inv.get_host("stowww1.example.com").get_vars()
         result = [
             u'com',
             u'example',
@@ -69,7 +68,7 @@ class AnsibleInventoryTests(unittest.TestCase):
         self.assertListEqual(yml['group_names'], result, msg="\nGot:    {}\nExpect: {}".format(yml['group_names'], result))
 
     def test_check_matcher_capture_on_lonwww2(self):
-        yml = self.yml_inv.get_vars("lonwww2.example.com")
+        yml = self.yml_inv.get_host("lonwww2.example.com").get_vars()
         result = [
             u'com',
             u'example',
@@ -88,7 +87,7 @@ class AnsibleInventoryTests(unittest.TestCase):
         self.assertListEqual(yml['group_names'], result, msg="\nGot:    {}\nExpect: {}".format(yml['group_names'], result))
 
     def test_check_matcher_capture_on_londb3(self):
-        yml = self.yml_inv.get_vars("londb3.example.com")
+        yml = self.yml_inv.get_host("londb3.example.com").get_vars()
         result = [
             u'com',
             u'db',

--- a/tests/test-name-root/inventory_tests.py
+++ b/tests/test-name-root/inventory_tests.py
@@ -34,21 +34,22 @@ import unittest
 import operator
 
 from ansible import errors
-from ansible.inventory import Inventory
+from ansible.inventory.manager import InventoryManager
 from ansible.parsing.dataloader import DataLoader
-from ansible.vars import VariableManager
+from ansible.vars.manager import VariableManager
 
 class AnsibleInventoryTests(unittest.TestCase):
-    var_manager = VariableManager()
     dataloader = DataLoader()
-    yml_inv = Inventory(
-        host_list="{}/inv.sh".format(os.path.dirname(__file__)),
-        loader=dataloader,
-        variable_manager=var_manager
+    yml_inv = InventoryManager(
+        sources="{}/inv.sh".format(os.path.dirname(__file__)),
+        loader=dataloader
     )
+    var_manager = VariableManager(loader=dataloader, inventory=yml_inv)
 
     def test_check_group_vars_host1(self):
-        yml = self.yml_inv.get_vars("myhost1.example.com")
+        yml = self.yml_inv.get_host("myhost1.example.com").get_vars()
+        yml.pop('inventory_file',None)
+        yml.pop('inventory_dir',None)
         result = {
             'inventory_hostname': u'myhost1.example.com',
             'group_names': [

--- a/tests/test-plain/inventory_tests.py
+++ b/tests/test-plain/inventory_tests.py
@@ -34,21 +34,21 @@ import unittest
 import operator
 
 from ansible import errors
-from ansible.inventory import Inventory
+from ansible.inventory.manager import InventoryManager
 from ansible.parsing.dataloader import DataLoader
-from ansible.vars import VariableManager
+from ansible.vars.manager import VariableManager
 
 class AnsibleInventoryTests(unittest.TestCase):
-    var_manager = VariableManager()
     dataloader = DataLoader()
-    yml_inv = Inventory(
-        host_list="{}/inv.sh".format(os.path.dirname(__file__)),
-        loader=dataloader,
-        variable_manager=var_manager
+    yml_inv = InventoryManager(
+        sources="{}/inv.sh".format(os.path.dirname(__file__)),
+        loader=dataloader
     )
 
     def test_check_host_vars_and_groups(self):
-        yml = self.yml_inv.get_vars("myhost1.example.com")
+        yml = self.yml_inv.get_host("myhost1.example.com").get_vars()
+        yml.pop('inventory_file',None)
+        yml.pop('inventory_dir',None)
         result = {
             'inventory_hostname': u'myhost1.example.com',
             'group_names': [
@@ -66,8 +66,8 @@ class AnsibleInventoryTests(unittest.TestCase):
         self.assertDictEqual(yml, result, msg="\nGot:    {}\nExpect: {}".format(yml, result))
 
     def test_list_hosts(self):
-        yml = sorted(self.yml_inv.list_hosts())
-        yml = list(map((lambda x : repr(x).decode('utf-8')), yml))
+        yml = self.yml_inv.list_hosts()
+        yml = sorted(list(map((lambda x : repr(x).decode('utf-8')), yml)))
         result = [u'myhost1.example.com', u'myhost2.example.com']
         self.assertListEqual(yml, result, msg="\nGot:    {}\nExpect: {}".format(yml, result))
 

--- a/tests/test-tags/inventory_tests.py
+++ b/tests/test-tags/inventory_tests.py
@@ -34,23 +34,24 @@ import unittest
 import operator
 
 from ansible import errors
-from ansible.inventory import Inventory
+from ansible.inventory.manager import InventoryManager
 
 from ansible import __version__ as ansible_version
 from ansible.parsing.dataloader import DataLoader
-from ansible.vars import VariableManager
+from ansible.vars.manager import VariableManager
 
 class AnsibleInventoryTests(unittest.TestCase):
     var_manager = VariableManager()
     dataloader = DataLoader()
-    yml_inv = Inventory(
-        host_list="{}/inv.sh".format(os.path.dirname(__file__)),
-        loader=dataloader,
-        variable_manager=var_manager
+    yml_inv = InventoryManager(
+        sources="{}/inv.sh".format(os.path.dirname(__file__)),
+        loader=dataloader
     )
 
     def test_check_host_with_tags(self):
-        yml = self.yml_inv.get_vars("myhost2.example.com")
+        yml = self.yml_inv.get_host("myhost2.example.com").get_vars()
+        yml.pop('inventory_file',None)
+        yml.pop('inventory_dir',None)
         result = {
             'inventory_hostname': u'myhost2.example.com',
             'group_names': [
@@ -70,7 +71,9 @@ class AnsibleInventoryTests(unittest.TestCase):
         self.assertDictEqual(yml, result, msg="\nGot:    {}\nExpect: {}".format(yml, result))
 
     def test_check_host_with_name_syntax(self):
-        yml = self.yml_inv.get_vars("myhost1.example.com")
+        yml = self.yml_inv.get_host("myhost1.example.com").get_vars()
+        yml.pop('inventory_file',None)
+        yml.pop('inventory_dir',None)
         result = {
             'inventory_hostname': u'myhost1.example.com',
             'group_names': [
@@ -89,8 +92,7 @@ class AnsibleInventoryTests(unittest.TestCase):
 
     def test_list_hosts(self):
         yml = self.yml_inv.list_hosts()
-        yml = list(map((lambda x : repr(x).decode('utf-8')), yml))
-        yml = sorted(yml)
+        yml = sorted(list(map((lambda x : repr(x).decode('utf-8')), yml)))
         result = [u'myhost1.example.com', u'myhost2.example.com']
         self.assertListEqual(yml, result, msg="\nGot:    {}\nExpect: {}".format(yml, result))
 

--- a/tests/test-tagvars/inventory_tests.py
+++ b/tests/test-tagvars/inventory_tests.py
@@ -34,34 +34,51 @@ import unittest
 import operator
 
 from ansible import errors
-from ansible.inventory import Inventory
+from ansible.inventory.manager import InventoryManager
 from ansible.parsing.dataloader import DataLoader
-from ansible.vars import VariableManager
+from ansible.vars.manager import VariableManager
 
 class AnsibleInventoryTests(unittest.TestCase):
-    var_manager = VariableManager()
     dataloader = DataLoader()
-    yml_inv = Inventory(
-        host_list="{}/inv.sh".format(os.path.dirname(__file__)),
+    yml_inv = InventoryManager(
+        sources="{}/inv.sh".format(os.path.dirname(__file__)),
         loader=dataloader,
-        variable_manager=var_manager
     )
+    var_manager = VariableManager(loader=dataloader, inventory=yml_inv)
 
     def test_check_tagvar_variable(self):
         host = self.yml_inv.list_hosts("myhost1.example.com")[0]
-        yml = self.var_manager.get_vars(self.dataloader, host=host)
+        yml = self.var_manager.get_vars(host=host)
         self.assertEqual(yml['version'], 1.8, msg="Tagvar variable not set")
 
-    def test_that_a_tagvars_supersedes_groupvar(self):
+    def test_that_a_groupvars_supersedes_tagvars(self):
         host = self.yml_inv.list_hosts("myhost1.example.com")[0]
-        yml = self.var_manager.get_vars(self.dataloader, host=host)
-        self.assertEqual(yml['env'], u'stage', msg="env failed, got {}".format(yml['env']))
+        yml = self.var_manager.get_vars(host=host)
+        self.assertEqual(yml['env'], u'prod', msg="env failed, got {}".format(yml['env']))
 
     def test_that_a_hostvars_supersedes_tagvars(self):
         host = self.yml_inv.list_hosts("myhost1.example.com")[0]
-        yml = self.var_manager.get_vars(self.dataloader, host=host)
+        yml = self.var_manager.get_vars(host=host)
         self.assertEqual(yml['app'], u'app1', msg="app failed, got {}".format(yml['app']))
 
 if __name__ == '__main__':
     print("\n### Execute test {}\n".format( __file__))
     unittest.main(verbosity=2)
+
+'''
+  
+root:
+  docker:
+    hosts:
+      - name: myhost1.example.com
+        app: app1
+  vars:
+    env: prod
+
+
+tagvars:
+  example:
+    version: 1.8
+    env: stage
+    app: app2
+'''

--- a/tests/test-tagvars/inventory_tests.py
+++ b/tests/test-tagvars/inventory_tests.py
@@ -64,21 +64,3 @@ class AnsibleInventoryTests(unittest.TestCase):
 if __name__ == '__main__':
     print("\n### Execute test {}\n".format( __file__))
     unittest.main(verbosity=2)
-
-'''
-  
-root:
-  docker:
-    hosts:
-      - name: myhost1.example.com
-        app: app1
-  vars:
-    env: prod
-
-
-tagvars:
-  example:
-    version: 1.8
-    env: stage
-    app: app2
-'''

--- a/tests/test-vars/inventory_tests.py
+++ b/tests/test-vars/inventory_tests.py
@@ -34,26 +34,26 @@ import unittest
 import operator
 
 from ansible import errors
-from ansible.inventory import Inventory
+from ansible.inventory.manager import InventoryManager
 
 from ansible.parsing.dataloader import DataLoader
-from ansible.vars import VariableManager
+from ansible.vars.manager import VariableManager
 
 class AnsibleInventoryTests(unittest.TestCase):
-    var_manager = VariableManager()
     dataloader = DataLoader()
-    yml_inv = Inventory(
-        host_list="{}/inv.sh".format(os.path.dirname(__file__)),
-        loader=dataloader,
-        variable_manager=var_manager
+    yml_inv = InventoryManager(
+        sources="{}/inv.sh".format(os.path.dirname(__file__)),
+        loader=dataloader
     )
+    var_manager = VariableManager(loader=dataloader, inventory=yml_inv)
+
 
     def test_check_host_var_number(self):
-        yml = self.yml_inv.get_vars("myhost2.example.com")
+        yml = self.yml_inv.get_host("myhost2.example.com").get_vars()
         self.assertEqual(yml['number'], 1, msg="Error, var number not a number")
 
     def test_check_host_var_string(self):
-        yml = self.yml_inv.get_vars("myhost2.example.com")
+        yml = self.yml_inv.get_host("myhost2.example.com").get_vars()
         self.assertEqual(yml['string'], u'foo', msg="Error, var string not a string")
 
 if __name__ == '__main__':


### PR DESCRIPTION
  - When using newer pyyaml inventory.py breaks due to YAML
    warnings. This patch uses yaml.full_load instead of yaml.load.

    More info here:
    https://github.com/yaml/pyyaml/wiki/PyYAML-yaml.load(input)-Deprecation

  - This adds requirement on PyYAML 5.1 so pip install
    that on base build.

  - Update tests to match against latest ansible (2.7.8) (probably
    breaks tests against old 2.0.0-stable, since precedence seemed to have
    changed for group_vars vs the tagvars.

    I inverted the test like this:
    ```
      -    def test_that_a_tagvars_supersedes_groupvar(self):
      +    def test_that_a_groupvars_supersedes_tagvars(self):
    ```

    The other tests where pretty minor relocation of used functions.

  - Also upgrade pip